### PR TITLE
update health-status.py escape re before searching logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Nginx terraform deployment to AWS
 
   1. The output of the terraform script should provide the aws LB url, open in browser.
 
-         export URL=$(terraform output | grep -oP '(?<=loadbalancerURL = ").+(?=")');echo "URL=$URL"
+         export URL=$(terraform output loadbalancerURL)|tr -d '"';echo "URL=$URL"
          echo "URL=$URL"
          # export URL="nginx-server......ap-southeast-2.elb.amazonaws.com"
          curl -is http://$URL/

--- a/scripts/health-status.py
+++ b/scripts/health-status.py
@@ -115,7 +115,7 @@ async def fetch_count_logs(
 async def log_search_regex(
               regex: str = Path(..., title='Slow Regex search e.g. "2021-12-08T21"')
 ):
-        r = re.compile(regex)
+        r = re.compile(re.escape(regex))
         tempdb: List[LogMsg] = []
         for l in db:
             if r.findall(json.dumps(l.logmsg)):


### PR DESCRIPTION
Fix un-secaped regular expressing found with python code scan. 